### PR TITLE
Remove bad inclusion of item-set-party.css

### DIFF
--- a/view/item-set-party/admin/item-set-party/resource.phtml
+++ b/view/item-set-party/admin/item-set-party/resource.phtml
@@ -1,5 +1,4 @@
 <?php $this->headScript()->appendFile($this->assetUrl('js/item-set-party.js', 'ItemSetParty'));?>
-<?php $this->headScript()->appendFile($this->assetUrl('css/item-set-party.css', 'ItemSetParty'));?>
 
 <?php 
     $resourceIcon = "o-icon-" . str_replace('_', '-', $resourceType);

--- a/view/item-set-party/block-layout/item-set-party-child.phtml
+++ b/view/item-set-party/block-layout/item-set-party-child.phtml
@@ -1,5 +1,3 @@
-<?php $this->headScript()->appendFile($this->assetUrl('css/item-set-party.css', 'ItemSetParty'));?>
-
 <ul>
     <?php if (isset($childRepresentation->values()["dcterms:hasPart"])): ?>
         <?php $hasPartValues = $childRepresentation->values()["dcterms:hasPart"]['values']; ?>

--- a/view/item-set-party/site/item-set-party/resource.phtml
+++ b/view/item-set-party/site/item-set-party/resource.phtml
@@ -1,5 +1,4 @@
 <?php $this->headScript()->appendFile($this->assetUrl('js/item-set-party.js', 'ItemSetParty'));?>
-<?php $this->headScript()->appendFile($this->assetUrl('css/item-set-party.css', 'ItemSetParty'));?>
 
 <?php 
     $resourceIcon = "o-icon-" . str_replace('_', '-', $resourceType);


### PR DESCRIPTION
It was included with a <script> tag which caused the following error in browser console:

Uncaught SyntaxError: unexpected token: identifier

Moreover, item-set-party.css is already included from the `view.layout` event listener, so there is no need to include it in the .phtml files